### PR TITLE
PEP 8 and other imrpovements

### DIFF
--- a/src/graphax/core.py
+++ b/src/graphax/core.py
@@ -11,7 +11,7 @@ from jax._src.util import safe_map
 import jax._src.core as core
 
 from .primitives import elemental_rules
-from .sparse.tensor import get_num_muls, get_num_adds, _checkify_tensor
+from .sparse.tensor import get_num_muls, get_num_adds, _assert_sparse_tensor_consistency
 from .sparse.utils import zeros_like, get_largest_tensor
 
 from jax._src import linear_util as lu
@@ -274,7 +274,7 @@ def unload_post_transforms(post, pre, iota):
     new_post = post.copy()
     for transform in pre.post_transforms:
         new_post = transform.apply_inverse(new_post, iota)
-    _checkify_tensor(new_post)
+    _assert_sparse_tensor_consistency(new_post)
     return new_post
 
 
@@ -282,7 +282,7 @@ def unload_pre_transforms(post, pre, iota):
     new_pre = pre.copy()
     for transform in post.pre_transforms:
         new_pre = transform.apply(new_pre, iota)
-    _checkify_tensor(new_pre)
+    _assert_sparse_tensor_consistency(new_pre)
     return new_pre
 
 
@@ -399,11 +399,11 @@ def _eliminate_vertex(vertex: int,
                     for transform in _edge.pre_transforms:
                         _edge = transform.apply_inverse(_edge, iota)
 
-                _checkify_tensor(edge_outval)
+                _assert_sparse_tensor_consistency(edge_outval)
                 edge_outval += _edge
                 num_add += get_num_adds(edge_outval, _edge)
                 
-            _checkify_tensor(edge_outval)
+            _assert_sparse_tensor_consistency(edge_outval)
             # print("Edge_outval:", edge_outval)
             graph[in_edge][out_edge] = edge_outval
             transpose_graph[out_edge][in_edge] = edge_outval
@@ -515,7 +515,7 @@ def _build_graph(jaxpr: core.Jaxpr,
         
     # Writes a new elemental partial to the graph and transpose_graph
     def write_elemental(outvar, invar, val):
-        _checkify_tensor(val)
+        _assert_sparse_tensor_consistency(val)
         if isinstance(invar, core.Var):
             graph[invar][outvar] = val
             transpose_graph[outvar][invar] = val

--- a/src/graphax/sparse/block.py
+++ b/src/graphax/sparse/block.py
@@ -1,16 +1,58 @@
-from typing import Any, Callable, Sequence, Tuple, Union
+from typing import Any, Callable, Sequence, Generator
+from chex import Array
 
 import jax
 import jax.numpy as jnp
+from tensor import SparseTensor
 
+# TODO: make parent class, or inherit sparse tensor ??
+
+@dataclass
+class DenseDimension:
+    id: int
+    size: int
+    val_dim: int | None
+
+@dataclass
+class SparseDimension:
+    id: int
+    size: int
+    val_dim: int
+    other_id: int
+
+Dimension = DenseDimension | SparseDimension
 
 class BlockSparseTensor:
     out_dims: Any
     primal_dims: Any
     shape: Sequence[int]
-    blocks: Sequence[jnp.ndarray]
+    blocks: Sequence[Array]
     pre_transforms: Sequence[Callable] 
     post_transforms: Sequence[Callable]
+
+    def __init__(self,
+                 out_dims: Sequence[Dimension],
+                 primal_dims: Sequence[Dimension],
+                 blocks: Sequence[Array],
+                 pre_transforms: Sequence[Callable] = None,
+                 post_transforms: Sequence[Callable] = None) -> None:
+
+        if pre_transforms is None:
+            pre_transforms = []
+        if post_transforms is None:
+            post_transforms = []
+
+        self.out_dims = out_dims if isinstance(out_dims, tuple) else tuple(out_dims)
+        self.primal_dims = primal_dims if isinstance(primal_dims, tuple) else tuple(primal_dims)
+
+        self.out_shape = [d.size for d in out_dims]
+        self.primal_shape = [d.size for d in primal_dims]
+
+        self.shape = tuple(self.out_shape + self.primal_shape)
+
+        self.blocks = blocks
+        self.pre_transforms = pre_transforms
+        self.post_transforms = post_transforms
 
     
 

--- a/src/graphax/sparse/custom_derivatives.py
+++ b/src/graphax/sparse/custom_derivatives.py
@@ -32,7 +32,7 @@ class CustomElementalCallPrimitive(core.Primitive):
         tracers = map(top_trace.full_raise, args)
         tracers = list(tracers)
 
-        if type(top_trace) is jax._src.interpreters.partial_eval.DynamicJaxprTrace:
+        if isinstance(top_trace, jax)._src.interpreters.partial_eval.DynamicJaxprTrace:
             outs = dynamic_jaxpr_custom_elemental_call(self, fn, elemental, tracers,
                                                         symbolic_zeros=symbolic_zeros)
         _, env_trace_todo = lu.merge_linear_aux(env_trace_todo1, env_trace_todo2)

--- a/src/graphax/sparse/tensor.py
+++ b/src/graphax/sparse/tensor.py
@@ -2,7 +2,7 @@
 Sparse tensor algebra implementation
 """
 import copy
-from typing import Callable, Sequence, Tuple, Union
+from typing import Callable, Sequence, Union, Generator
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
@@ -13,107 +13,117 @@ from jax.tree_util import register_pytree_node_class
 from chex import Array
 
 from .utils import eye_like_copy, eye_like
+from dataclasses import dataclass
 
 
-# NOTE: a val_dim of None means that we have a possible replication of the tensor 
-# along the respective dimension `d.size` times to manage broadcasting 
-# operations such as broadcasted additions or multiplications.
-# TODO what do we when we have a tensor that consists only of DenseDimensions 
-# with val_dim=None?
+# NOTE: a val_dim of None means that we have a possible replication of the tensor
+#   along the respective dimension `d.size` times to manage broadcasting
+#   operations such as broadcasted additions or multiplications.
+# TODO: what do we do when we have a tensor that consists only of DenseDimensions
+#   with val_dim=None?
+@dataclass
 class DenseDimension:
     id: int
     size: int
-    val_dim: int
-    
-    def __init__(self, id: int, size: int, val_dim: int) -> None:
-        self.id = id
-        self.size = size
-        self.val_dim = val_dim
-        
-    def __repr__(self) -> str:
-        return f"DenseDimension(id={self.id}, size={self.size}, val_dim={self.val_dim})"
-
+    val_dim: int | None
 
 # NOTE: a val_dim of None means that we have a factored Kronecker delta in
-# our tensor at the respective dimensions.
-# Also we can have unmatching size and val.shape[d.val_dim] for SparseDimensions
-# if the size is 1. This is necessary to enable broadcasting operations.
+#   our tensor at the respective dimensions.
+#   Also we can have unmatching size and val.shape[d.val_dim] for SparseDimensions
+#   if the size is 1. This is necessary to enable broadcasting operations.
+@dataclass
 class SparseDimension:
     id: int
     size: int
     val_dim: int
     other_id: int
-    
-    def __init__(self, id: int, size: int, val_dim: int, other_id: int) -> None:
-        self.id = id
-        self.size = size
-        self.val_dim = val_dim
-        self.other_id = other_id
-        
-    def __repr__(self) -> str:
-        return f"SparseDimension(id={self.id}, size={self.size}, val_dim={self.val_dim}, other_id={self.other_id})"
 
-
-Dimension = Union[DenseDimension, SparseDimension]
+Dimension = DenseDimension | SparseDimension
         
 
 class SparseTensor:
     """
     The `SparseTensor object enables` the representation of sparse tensors
-    that 
-    if out_dims or primal_dims is empty, this implies a scalar dependent or
-    independent variable. 
-    if both are empty, then we have a scalar value and everything becomes trivial
-    and the `val` field contains the value of the singleton partial
+    that if out_dims or primal_dims is empty, this implies a scalar dependent or
+    independent variable. if both are empty, then we have a scalar value and
+    everything becomes trivial and the `val` field contains the value of the
+    singleton partial
     """
-    out_dims: Sequence[Dimension]
-    primal_dims: Sequence[Dimension] # input dimensions
-    shape: Sequence[int] # True shape of the tensor
-    val: ShapedArray
-    pre_transforms: Sequence[Callable] 
+    out_dims: tuple[Dimension]
+    primal_dims: tuple[Dimension] # input dimensions
+    shape: tuple[int] # True shape of the tensor
+    val: Array
+    pre_transforms: Sequence[Callable]
     post_transforms: Sequence[Callable]
     # NOTE: Document pre_transforms and post_transforms. what about addition?
     # NOTE: We always assume that the dimensions are ordered in ascending order
     
     def __init__(self, 
-                out_dims: Sequence[Dimension], 
-                primal_dims: Sequence[Dimension], 
-                val: ShapedArray, 
-                pre_transforms: Sequence[Callable] = [],
-                post_transforms: Sequence[Callable] = []) -> None:
-                
-        self.out_dims = out_dims if type(out_dims) is Tuple else tuple(out_dims)
-        self.primal_dims = primal_dims if type(primal_dims) is Tuple else tuple(primal_dims)
-        out_shape = [d.size for d in out_dims]
-        primal_shape = [d.size for d in primal_dims]
-        self.shape = tuple(out_shape + primal_shape)
-        self.out_shape = [str(s) for s in out_shape]
-        self.primal_shape = [str(s) for s in primal_shape]
+                 out_dims: Sequence[Dimension],
+                 primal_dims: Sequence[Dimension],
+                 val: Array,
+                 pre_transforms: Sequence[Callable] = None,
+                 post_transforms: Sequence[Callable] = None) -> None:
+
+        if pre_transforms is None:
+            pre_transforms = []
+        if post_transforms is None:
+            post_transforms = []
+
+        self.out_dims = out_dims if isinstance(out_dims, tuple) else tuple(out_dims)
+        self.primal_dims = primal_dims if isinstance(primal_dims, tuple) else tuple(primal_dims)
+
+        self.out_shape = [d.size for d in out_dims]
+        self.primal_shape = [d.size for d in primal_dims]
+
+        self.shape = tuple(self.out_shape + self.primal_shape)
+
         self.val = val
         self.pre_transforms = pre_transforms
         self.post_transforms = post_transforms
+
+        _assert_sparse_tensor_consistency(self)
             
     def __repr__(self) -> str:
-        return f"SparseTensor(\n" \
-                f"   shape = (" + f",".join(self.out_shape) + f"|" + f",".join(self.primal_shape) + "),\n" \
-                f"   out_dims = {self.out_dims},\n" \
-                f"   primal_dims = {self.primal_dims},\n" \
-                f"   val = {self.val},\n" \
-                f"   pre_transforms = {self.pre_transforms},\n" \
-                f"   post_transforms = {self.post_transforms})\n"
+        def map_str(a: Sequence) -> Generator:
+            return (str(s) for s in a)
+
+        def multiline_seq(s: Sequence, brackets: str) -> str:
+            lb, rb, *_ = brackets
+            if s:
+                res = f'{lb}\n\t\t' + ',\n\t\t'.join(map_str(s)) + f',\n\t{rb}'
+            else:
+                res = lb + rb
+            return res
+
+        str_out_shape = ', '.join(map_str(self.out_shape))
+        str_primal_shape = ', '.join(map_str(self.primal_shape))
+
+        multiline_out_dims = multiline_seq(self.out_dims, '()')
+        multiline_primal_dims = multiline_seq(self.primal_dims, '()')
+        multiline_pre_transform = multiline_seq(self.pre_transforms, '[]')
+        multiline_post_transform = multiline_seq(self.post_transforms, '[]')
+
+        return f"""SparseTensor(
+    shape = ({str_out_shape} | {str_primal_shape}),
+    out_dims = {multiline_out_dims},
+    primal_dims = {multiline_primal_dims},
+    val = {self.val},
+    pre_transforms = {multiline_pre_transform},
+    post_transforms = {multiline_post_transform}
+)"""
                     
     def __add__(self, _tensor):
         return _add(self, _tensor)
     
     def __mul__(self, _tensor):
         return _mul(self, _tensor)
-                    
+
+    # TODO: add the case where `val_dim = None` for a `DenseDimension` by
+    #   replicating the tensor `d.size` times using `jnp.tile`.
     def dense(self, iota: Array) -> Array:
         """
         Materializes tensor to actual dense shape.
-        
-        TODO add the case where `val_dim = None` for a `DenseDimension` by
-        replicating the tensor `d.size` times using `jnp.tile`.
 
         Args:
             iota (Array): The Kronecker matrix/tensor that is used to 
@@ -126,12 +136,13 @@ class SparseTensor:
         # will get multiplied to manifest the sparse dimensions  
         # If tensor contains SparseDimensions, we have to materialize them
         def eye_dim_fn(d: Dimension) -> int:
-            if type(d) is SparseDimension:
+            if isinstance(d, SparseDimension):
                 return d.size
             else:
                 return 1
-            
-        eye_shape = [eye_dim_fn(d) for d in self.out_dims+self.primal_dims]
+
+        eye_shape = [eye_dim_fn(d) for d in self.out_dims + self.primal_dims]
+
         # If tensor consists only out of Kronecker Delta's, we can just reshape
         # the eye matrix to the shape of the tensor and return it
         if self.val is None: 
@@ -141,25 +152,26 @@ class SparseTensor:
             return self.val
         
         # Catching some corner cases
-        if len(self.out_dims) == 0 and len(self.primal_dims) == 0:
+        if not self.out_dims and not self.primal_dims:
             return self.val
         
         shape = _get_fully_materialized_shape(self)   
         
-        # Get the tiling for DenseDimensions with val_dim = None, i.e. replicating
+        # Get the tiling for DenseDimensions with `val_dim = None`, i.e. replicating
         # dimensions
         def tile_dim_fn(d: Dimension) -> int:
-            if type(d) is DenseDimension and d.val_dim is None:
+            if isinstance(d, DenseDimension) and d.val_dim is None:
                 return d.size
             else:
                 return 1
-        tiling = [tile_dim_fn(d) for d in self.out_dims+self.primal_dims]
+
+        tiling = [tile_dim_fn(d) for d in self.out_dims + self.primal_dims]
 
         val = self.val.reshape(shape)
         index_map = eye_like_copy(eye_shape, len(self.out_dims), iota)
         return jnp.tile(index_map*val, tiling)
         
-    def copy(self, val=None):
+    def copy(self, val: Array = None):
         """
         Function that copies the given sparse tensor object entirely except for
         the `val` property which can be replaced by a new value.
@@ -190,7 +202,7 @@ def sparse_tensor_zeros_like(st: SparseTensor) -> SparseTensor:
     return st.copy(jnp.zeros_like(st.val))
     
     
-def _checkify_tensor(st: SparseTensor) -> bool:
+def _assert_sparse_tensor_consistency(st: SparseTensor):
     """
     Function that validates the consistency of a `SparseTensor` object,
     i.e. checks if the `val` property has the correct shape and if the dimensions
@@ -203,13 +215,22 @@ def _checkify_tensor(st: SparseTensor) -> bool:
         bool: True if the `SparseTensor` object is consistent.
     """
     # Check if d.size matches val.shape[d.val_dim] for all d
-    matching_size = all([d.size == st.val.shape[d.val_dim] 
-                        if d.val_dim is not None and type(d) is DenseDimension
-                        else True for d in st.out_dims + st.primal_dims])
-    
-    matching_size += all([d.size == st.val.shape[d.val_dim] or d.size == 1 
-                        if d.val_dim is not None and type(d) is SparseDimension
-                        else True for d in st.out_dims + st.primal_dims])
+    matching_sparse_sizes = all(
+        d.size == st.val.shape[d.val_dim]
+        or d.size == 1
+        if isinstance(d, SparseDimension)
+        and d.val_dim is not None else True
+        for d in st.out_dims + st.primal_dims
+    )
+
+    matching_dense_sizes = all(
+        d.size == st.val.shape[d.val_dim]
+        if isinstance(d, DenseDimension)
+        and d.val_dim is not None else True
+        for d in st.out_dims + st.primal_dims
+    )
+
+    matching_sizes = matching_sparse_sizes or matching_dense_sizes
         
     unique_out_dims = [d.val_dim for d in st.out_dims if d.val_dim is not None]
     unique_primal_dims = [d.val_dim for d in st.primal_dims if d.val_dim is not None]
@@ -217,32 +238,30 @@ def _checkify_tensor(st: SparseTensor) -> bool:
     is_uniqe_out_dims = len(unique_out_dims) == len(set(unique_out_dims))
     is_uniqe_primal_dims = len(unique_primal_dims) == len(set(unique_primal_dims))
     has_uniqe_dims = is_uniqe_out_dims and is_uniqe_primal_dims
-    
-    matching_id = True
-    matching_sparse_ids = True
-    for i, d in enumerate(st.out_dims):
-        if i == d.id:
-            matching_id *= True
-        else:
-            matching_id *= False
-        if type(d) is SparseDimension:
-            _d = st.primal_dims[d.other_id-len(st.out_dims)]
-            if d.id == _d.other_id and d.other_id == _d.id:
-                matching_sparse_ids *= True
-            else:
-                matching_sparse_ids *= False
-                    
-    # TODO speed this up with a list comprehension                
-    for i, d in enumerate(st.primal_dims, start=len(st.out_dims)):
-        if i == d.id:
-            matching_id *= True
-        else:
-            matching_id *= False
-        
-    return matching_size and matching_id and has_uniqe_dims and matching_sparse_ids
-    
 
-def _get_fully_materialized_shape(st: SparseTensor) -> Tuple[int]:
+    # Check if IDs in out_dims and primal_dims match their index positions
+    matching_id = all(
+        od.id == i and pd.id == i + len(st.out_dims)
+        for i, (od, pd) in enumerate(zip(st.out_dims, st.primal_dims))
+    )
+
+    # Check sparse dimension pairing consistency
+    matching_sparse_ids = all(
+        st.primal_dims[d.other_id - len(st.out_dims)].other_id == d.id
+        if isinstance(d, SparseDimension) else True
+        for d in st.out_dims
+    )
+
+    assert (matching_sizes
+            and has_uniqe_dims
+            and matching_id
+            and matching_sparse_ids
+    ), f"{st} is not self-consistent!"
+
+    # TODO: check if val is consistent with tensor structure?
+
+
+def _get_fully_materialized_shape(st: SparseTensor) -> tuple[int]:
     """
     Function that returns the shape of a `SparseTensor` object if its 'val' 
     property would be fully materialized. Dimensions of size one are inserted 
@@ -256,29 +275,27 @@ def _get_fully_materialized_shape(st: SparseTensor) -> Tuple[int]:
             SparseDimensions gets the val property. Defaults to False.
 
     Returns:
-        Tuple[int]: The fully materialized shape.
+        tuple[int]: The fully materialized shape.
     """
     # Compute out_dims full shape-mul
     def out_dim_fn(d: Dimension) -> int:
-        if d.val_dim is None:
+        # NOTE we need the case `d.size != st.val.shape[d.val_dim]` because SparseDimensions can be matrialized without
+        #   the correct d.size property
+        if d.val_dim is None or d.size != st.val.shape[d.val_dim]:
             return 1
-        elif d.size != st.val.shape[d.val_dim]:
-            return 1 # NOTE we need this case because SparseDimensions can be matrialized without the correct d.size property
         else:
             return d.size
         
-    out_shape = [out_dim_fn(d) for d in st.out_dims]
+    out_shape = tuple(out_dim_fn(d) for d in st.out_dims)
            
     # Compute primal_dims full shape
     def primal_dim_fn(d: Dimension) -> int:
-        if type(d) is SparseDimension:
+        if isinstance(d, SparseDimension) or d.val_dim is None:
             return 1
         else:
-            if d.val_dim is None:
-                return 1
-            else:
-                return d.size
-    primal_shape = [primal_dim_fn(d) for d in st.primal_dims]
+            return d.size
+
+    primal_shape = tuple(primal_dim_fn(d) for d in st.primal_dims)
 
     return out_shape + primal_shape
 
@@ -295,8 +312,8 @@ def _is_pure_dot_product_mul(lhs: SparseTensor, rhs: SparseTensor) -> bool:
     Returns:
         bool: Are the tensors compatible for multiplication?
     """
-    return all([True if type(r) is DenseDimension and type(l) is DenseDimension
-                else False for r, l in zip(lhs.primal_dims, rhs.out_dims)])
+    return all(True if isinstance(r, DenseDimension) and isinstance(l, DenseDimension)
+               else False for r, l in zip(lhs.primal_dims, rhs.out_dims))
 
 
 def _is_pure_broadcast_mul(lhs: SparseTensor, rhs: SparseTensor) -> bool:
@@ -311,8 +328,8 @@ def _is_pure_broadcast_mul(lhs: SparseTensor, rhs: SparseTensor) -> bool:
     Returns:
         bool: Are the tensors compatible for multiplication?
     """
-    return all([True if type(r) is SparseDimension or type(l) is SparseDimension
-                else False for r, l in zip(lhs.primal_dims, rhs.out_dims)])
+    return all(True if isinstance(r, SparseDimension) or isinstance(r, SparseDimension)
+               else False for r, l in zip(lhs.primal_dims, rhs.out_dims))
 
     
 def _mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
@@ -330,20 +347,20 @@ def _mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
 
     Returns:
         SparseTensor: The resulting `SparseTensor` object.
-    """                                   
-    assert _checkify_tensor(lhs), f"{lhs} is not self-consistent!"
-    assert _checkify_tensor(rhs), f"{rhs} is not self-consistent!"
-    l = len(lhs.out_dims)
-    r = len(rhs.out_dims) 
-    assert lhs.shape[l:] == rhs.shape[:r], f"{lhs.shape} and {rhs.shape} "\
-                                        "not compatible for multiplication!"
+    """
+    _assert_sparse_tensor_consistency(lhs)
+    _assert_sparse_tensor_consistency(rhs)
 
-    res = None
+    l = len(lhs.out_dims)
+    r = len(rhs.out_dims)
+    assert lhs.shape[l:] == rhs.shape[:r], \
+        f"{lhs.shape} and {rhs.shape} not compatible for multiplication!"
+
     _lhs = lhs.copy()
     _rhs = rhs.copy()
     if lhs.shape == () and rhs.shape == ():
         # If both tensors are scalars, we can just multiply them directly
-        return SparseTensor((), (), lhs.val*rhs.val)
+        res = SparseTensor((), (), lhs.val*rhs.val)
     elif _is_pure_dot_product_mul(_lhs, _rhs):
         res = _pure_dot_product_mul(_lhs, _rhs)
     elif _is_pure_broadcast_mul(_lhs, _rhs):
@@ -351,7 +368,7 @@ def _mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
     else:
         res = _mixed_mul(_lhs, _rhs)
 
-    assert _checkify_tensor(res), f"{res} is not self-consistent!"
+    _assert_sparse_tensor_consistency(res)
     return res
 
 
@@ -368,21 +385,24 @@ def _add(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
 
     Returns:
         SparseTensor: The resulting `SparseTensor` object.
-    """                           
-    assert _checkify_tensor(lhs), f"{lhs} is not self-consistent!"
-    assert _checkify_tensor(rhs), f"{rhs} is not self-consistent!"
+    """
+    _assert_sparse_tensor_consistency(lhs)
+    _assert_sparse_tensor_consistency(rhs)
 
-    assert lhs.shape == rhs.shape, f"{lhs.shape} and {rhs.shape} "\
-                                        "not compatible for addition!"
+    assert lhs.shape == rhs.shape, \
+        f"{lhs.shape} and {rhs.shape} not compatible for addition!"
     
     res = _sparse_add(lhs, rhs)
     
-    assert _checkify_tensor(res), f"{res} is not self-consistent!"
+    _assert_sparse_tensor_consistency(res)
     return res
 
+def _get_other_val_dim(d: Dimension, st: SparseTensor) -> Dimension:
+    pass
 
-def _get_other_val_dim(d: Dimension, st: SparseTensor) -> int:
-    """Function that computes the new `val_dim` of a `SparseDimension` object
+def _get_new_val_dim(d: Dimension, st: SparseTensor) -> int | None:
+    """
+    Function that computes the new `val_dim` of a `SparseDimension` object
     so that it's position within the `val` property matches the relative position
     of the corresponding `SparseDimension` object in the `primal_dims` list.
     
@@ -394,7 +414,6 @@ def _get_other_val_dim(d: Dimension, st: SparseTensor) -> int:
         int: The new `val_dim` of the `d` object.
     """
     l = len(st.out_dims)
-    dims = []
     if d.id < d.other_id:
         dims = st.out_dims + st.primal_dims[:d.other_id-l]
     else:
@@ -409,51 +428,51 @@ def _get_other_val_dim(d: Dimension, st: SparseTensor) -> int:
 
 
 def _get_padding(lhs_out_dims: Sequence[Dimension], 
-                rhs_primal_dims: Sequence[Dimension])-> Tuple[int]:
-    """Function that calculates how many dimensions have to be prepended/appended
+                 rhs_primal_dims: Sequence[Dimension]) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """
+    Function that calculates how many dimensions have to be prepended/appended
     to the `val` property of a `SparseTensor` to make it compatible for broadcast
     multiplication with another `SparseTensor`.
     
     Removes excess dimensions which are artifacts of `SparseTensor` objects.
 
     Args:
-        lhs (SparseDimension): SparseDimension object whose `val` property we 
-                                want to multiply with `rhs.val`.
-        rhs (SparseDimension): SparseDimension object whose `val` property we
-                                want to multiply with `lhs.val`.
+        lhs_out_dims (SparseDimension):
+            SparseDimension object whose `val` property we want to multiply with `rhs.val`.
+        rhs_primal_dims (SparseDimension):
+            SparseDimension object whose `val` property we want to multiply with `lhs.val`.
 
     Returns:
-        Tuple[int]: Tuple of integers that tells us how many dimensions we have
-                    to append/prepend to the `val` property of `lhs` and `rhs`.
+        tuple[tuple[int, ...], tuple[int, ...]]:
+            tuple of integers that tells us how many dimensions we have to
+            append/prepend to the `val` property of `lhs` and `rhs`.
     """
     # Calculate where we have to add additional dimensions to rhs.val
     # due to DenseDimensions in lhs.out_dims    
-    lhs_pad = tuple(1 for d in rhs_primal_dims if type(d) is DenseDimension and d.val_dim is not None)
-    rhs_pad = tuple(1 for d in lhs_out_dims if type(d) is DenseDimension and d.val_dim is not None)
+    lhs_pad = tuple(1 for d in rhs_primal_dims if isinstance(d, DenseDimension) and d.val_dim is not None)
+    rhs_pad = tuple(1 for d in lhs_out_dims if isinstance(d, DenseDimension) and d.val_dim is not None)
     return lhs_pad, rhs_pad
 
 
-def _checkify_broadcast_compatibility(lhs_val: Array, rhs_val: Array) -> bool:
+def _assert_broadcast_compatibility(lhs_val: Array, rhs_val: Array):
     """
     Function that checks if two arrays are compatible for broadcast multiplication. 
     
     Args:
         lhs_val (Array): Array that we want to multiply with `rhs_val`.
         rhs_val (Array): Array that we want to multiply with `lhs_val`.
-        
-    Returns:
-        bool: True if the arrays are compatible for broadcast multiplication,
     """
-    lhs_shape = lhs_val.shape
-    rhs_shape = rhs_val.shape
-    assert len(lhs_shape) == len(rhs_shape), f"Shapes {lhs_shape} and {rhs_shape}"\
-                                                " not compatible for broadcast_mul!"
-    return all([(ls == rs or ls == 1 or rs == 1) 
-                for (ls, rs) in zip(lhs_shape, rhs_shape)])
-    
-    
+    assert (
+        len(lhs_val.shape) == len(rhs_val.shape)
+        and all(
+            (ls == rs or ls == 1 or rs == 1)
+            for (ls, rs) in zip(lhs_val.shape, rhs_val.shape)
+        )
+    ), f"Shapes {lhs_val.shape} and {rhs_val.shape} not compatible for broadcast multiplication!"
+
+
 def _get_permutation_from_tensor(st: SparseTensor,
-                                shape: Sequence[int] = None) -> Sequence[int]:
+                                 shape: Sequence[int] = None) -> list[int]:
     """
     Function that calculates the permutation of the axes of the `val` property
     so as that `st.val.shape` matches `shape`. This is necessary to enable proper
@@ -470,22 +489,21 @@ def _get_permutation_from_tensor(st: SparseTensor,
                         `shape`.
     """
     shape = shape if shape is not None else st.val.shape
-    permutation = [0]*len(st.val.shape)
+    permutation = [0]*len(shape)
     
     i = 0
     for d in st.out_dims + st.primal_dims:
         if d.val_dim is not None:
-            if type(d) is DenseDimension:
+            if isinstance(d, DenseDimension):
                 permutation[d.val_dim] = i
                 i += 1
-            else:
-                if d.id < d.other_id:
-                    permutation[d.val_dim] = i
-                    i += 1
+            elif d.id < d.other_id:
+                permutation[d.val_dim] = i
+                i += 1
     return permutation
 
 
-def _get_val_shape(st: SparseTensor) -> Sequence[int]:
+def _get_val_shape(st: SparseTensor) -> list[int]:
     """
     Function that computes the shape of the `val` property of a `SparseTensor`
     from its corresponding `Dimension` objects.
@@ -506,9 +524,8 @@ def _get_val_shape(st: SparseTensor) -> Sequence[int]:
             shape[d.val_dim] = d.size
             
     for d in st.primal_dims:
-        if d.val_dim is not None:
-            if type(d) is DenseDimension:
-                shape[d.val_dim] = d.size
+        if d.val_dim is not None and isinstance(d, DenseDimension):
+            shape[d.val_dim] = d.size
     return shape
 
 
@@ -529,22 +546,24 @@ def _swap_axes(st: SparseTensor) -> SparseTensor:
     Returns:
         SparseTensor: SparseTensor object with appropriately swapped `val` property.
     """
-    transposed_shape = [d.size for d in st.out_dims if type(d) is DenseDimension]
+    transposed_shape = [d.size for d in st.out_dims if isinstance(d, DenseDimension)]
     transposed_shape += [d.size for d in st.primal_dims if d.val_dim is not None]
     
     l = len(st.out_dims)
     for ld in st.out_dims:
         # NOTE: not sure if this is a good solution to the problem at hand:
         if transposed_shape == _get_val_shape(st):
-                break
-        if type(ld) is SparseDimension and ld.val_dim is not None:
-            other_val_dim = _get_other_val_dim(ld, st)
+            break
+        if isinstance(ld, SparseDimension) and ld.val_dim is not None:
+            new_val_dim = _get_new_val_dim(ld, st)
             for d in st.out_dims + st.primal_dims:
-                if d.id != ld.id and d.id != ld.other_id:
-                    if d.val_dim is not None and d.val_dim >= ld.val_dim and d.val_dim <= other_val_dim:
-                        d.val_dim -= 1
-            ld.val_dim = other_val_dim
-            st.primal_dims[ld.other_id-l].val_dim = other_val_dim
+                if (d.id != ld.id
+                    and d.id != ld.other_id
+                    and d.val_dim is not None
+                    and ld.val_dim <= d.val_dim <= new_val_dim):
+                    d.val_dim -= 1
+            ld.val_dim = new_val_dim
+            st.primal_dims[ld.other_id-l].val_dim = new_val_dim
 
     permutation = _get_permutation_from_tensor(st)
     st.val = jnp.transpose(st.val, permutation)
@@ -552,7 +571,8 @@ def _swap_axes(st: SparseTensor) -> SparseTensor:
 
 
 def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
-    """Function that pads the `val` properties of two `SparseTensor` objects for 
+    """
+    Function that pads the `val` properties of two `SparseTensor` objects for
     proper broadcast multiplication. It does the following three things:
         1. It appends new axes to the `lhs` tensor for every `DenseDimension` in
             the `rhs.primal_dims` list.
@@ -590,10 +610,10 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
                             pad for broadcasting multiplication.
     
     Returns:
-        Tuple[SparseTensor, SparseTensor]: Tuple of SparseTensor objects with
-                                            appropriately padded `val` properties
-                                            and corresponding changes to the
-                                            `val_dim` properties.
+        tuple[SparseTensor, SparseTensor]: tuple of SparseTensor objects with
+                                           appropriately padded `val` properties
+                                           and corresponding changes to the
+                                           `val_dim` properties.
     """
     lhs_shape, rhs_shape = list(lhs.val.shape), list(rhs.val.shape)
     r = len(rhs.out_dims)
@@ -602,10 +622,9 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
     ### Update dimension numbers
     for rd in rhs.out_dims + rhs.primal_dims:
         if rd.val_dim is not None:
-            if type(rd) is DenseDimension:
+            if isinstance(rd, DenseDimension):
                 rd.val_dim += len(rhs_pad)
-            else:
-                if rd.id < rd.other_id:
+            elif rd.id < rd.other_id:
                     rd.val_dim += len(rhs_pad)
                     primal_dim = rhs.primal_dims[rd.other_id-r]
                     primal_dim.val_dim += len(rhs_pad)
@@ -618,8 +637,8 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
         if ld.val_dim is None and rd.val_dim is None:
             continue
         # ld is sparse
-        if ld.val_dim is None and type(ld) is SparseDimension:
-            other_val_dim = _get_other_val_dim(ld, lhs)
+        if ld.val_dim is None and isinstance(ld, SparseDimension):
+            other_val_dim = _get_new_val_dim(ld, lhs)
             if other_val_dim is not None:
                 other_val_dim += 1
             else:
@@ -628,13 +647,16 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
             lhs_shape.insert(other_val_dim, 1)
             ld.val_dim = other_val_dim
             lhs.out_dims[ld.other_id].val_dim = other_val_dim
+
             for d in lhs.out_dims + lhs.primal_dims:
-                if d.id != ld.id and d.id != ld.other_id:
-                    if d.val_dim is not None and d.val_dim >= other_val_dim:
-                        d.val_dim += 1
+                if (d.id != ld.id
+                    and d.id != ld.other_id
+                    and d.val_dim is not None
+                    and d.val_dim >= other_val_dim):
+                    d.val_dim += 1
                    
         # rd is sparse
-        elif rd.val_dim is None and type(rd) is SparseDimension:
+        elif rd.val_dim is None and isinstance(rd, SparseDimension):
             dims = [d.val_dim for d in rhs.out_dims[:rd.id] if d.val_dim is not None]
             new_val_dim = 0
             if len(dims) > 0:
@@ -645,12 +667,14 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
             rhs.primal_dims[rd.other_id-r].val_dim = new_val_dim
 
             for d in rhs.out_dims + rhs.primal_dims:
-                if d.id != rd.id and d.id != rd.other_id:
-                    if d.val_dim is not None and d.val_dim >= new_val_dim:
-                        d.val_dim += 1    
+                if (d.id != rd.id
+                    and d.id != rd.other_id
+                    and d.val_dim is not None
+                    and d.val_dim >= new_val_dim):
+                    d.val_dim += 1
                         
         # ld is replicating        
-        elif ld.val_dim is None and type(ld) is DenseDimension:
+        elif ld.val_dim is None and isinstance(ld, DenseDimension):
             new_val_dim = _get_val_dim_when_swapped(lhs, ld.id) # cannot use this here!
 
             lhs_shape.insert(new_val_dim, 1)
@@ -662,7 +686,7 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
                         d.val_dim += 1
         
         # rd is replicating        
-        elif rd.val_dim is None and type(rd) is DenseDimension:
+        elif rd.val_dim is None and isinstance(rd, DenseDimension):
             new_val_dim = _get_val_dim(rhs, rd.id)
             # dims = [d.val_dim for d in rhs.out_dims[:rd.id] if d.val_dim is not None]
             # new_val_dim = 0
@@ -672,9 +696,10 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
             rd.val_dim = new_val_dim
 
             for d in rhs.out_dims + rhs.primal_dims:
-                if d.id != rd.id:
-                    if d.val_dim is not None and d.val_dim >= new_val_dim:
-                        d.val_dim += 1    
+                if (d.id != rd.id
+                    and d.val_dim is not None
+                    and d.val_dim >= new_val_dim):
+                    d.val_dim += 1
 
     # TODO instead of reshape use `jnp.expand_dims here!`
     ### Needs some serious fixing !#######################################
@@ -690,7 +715,8 @@ def _pad_tensors(lhs: SparseTensor, rhs: SparseTensor):
 
 
 def _swap_back_axes(st: SparseTensor) -> SparseTensor:
-    """After two `SparseTensor` objects have been broadcast multiplied, the
+    """
+    After two `SparseTensor` objects have been broadcast multiplied, the
     resulting tensor usually has the `val` not reshaped so that the dimensions
     of it are sorted in ascending order according to the order in which the
     corresponding dimensions appear. This function does this.
@@ -717,7 +743,7 @@ def _swap_back_axes(st: SparseTensor) -> SparseTensor:
     permutation = [0]*len(st.val.shape)
     for d in st.out_dims + st.primal_dims:
         if d.val_dim is not None:
-            if type(d) is DenseDimension:
+            if isinstance(d, DenseDimension):
                 permutation[i] = d.val_dim
                 i += 1
             else:
@@ -730,7 +756,7 @@ def _swap_back_axes(st: SparseTensor) -> SparseTensor:
     i = 0
     for d in st.out_dims + st.primal_dims:
         if d.val_dim is not None:
-            if type(d) is DenseDimension:
+            if isinstance(d, DenseDimension):
                 d.val_dim = i
                 i += 1
             else:
@@ -772,7 +798,7 @@ def _get_output_tensor(lhs: SparseTensor,
     l, r = len(lhs.out_dims), len(rhs.out_dims)
     
     for ld in lhs.out_dims:
-        if type(ld) is DenseDimension:
+        if isinstance(ld, DenseDimension):
             new_out_dims.append(DenseDimension(ld.id, ld.size, ld.val_dim))
         else:
             # `d` is a SparseDimension and we know it has a corresponding friend
@@ -780,7 +806,7 @@ def _get_output_tensor(lhs: SparseTensor,
             # it will get contracted.
             idx = ld.other_id - l
             rd = rhs.out_dims[idx]
-            if type(rd) is DenseDimension:
+            if isinstance(rd, DenseDimension):
                 new_out_dims.append(DenseDimension(ld.id, ld.size, ld.val_dim))
             else:          
                 other_id = rd.other_id-r+l
@@ -791,13 +817,13 @@ def _get_output_tensor(lhs: SparseTensor,
     # due to DenseDimensions in rhs.primal_dims
     new_dense_dims = []
     for rd in rhs.primal_dims:
-        if type(rd) is DenseDimension:
+        if isinstance(rd, DenseDimension):
             # shift = sum([1 for dim in new_dense_dims if dim <= rd.val_dim])
             new_primal_dims.insert(rd.id-r, DenseDimension(rd.id-r+l, rd.size, rd.val_dim))
         else:
             idx = rd.other_id - r
             ld = lhs.primal_dims[idx]
-            if type(ld) is DenseDimension:
+            if isinstance(ld, DenseDimension):
                 new_dense_dims.append(ld.val_dim)
                 new_primal_dims.insert(rd.id-r, DenseDimension(rd.id-r+l, ld.size, ld.val_dim))                 
     
@@ -840,7 +866,7 @@ def _pure_broadcast_mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
         # Add padding
         lhs, rhs = _pad_tensors(lhs, rhs)
             
-        assert _checkify_broadcast_compatibility(lhs.val, rhs.val), f"Shapes {lhs.val.shape} and {rhs.val.shape} not compatible for broadcast multiplication!"
+        _assert_broadcast_compatibility(lhs.val, rhs.val)
         new_val = lhs.val * rhs.val
         out = _get_output_tensor(lhs, rhs, new_val)
         res = _swap_back_axes(out)
@@ -864,10 +890,9 @@ def _get_val_dim(st: SparseTensor, id: int) -> int:
     i = 0
     for d in dims[:id]:
         if d.val_dim is not None:
-            if type(d) is DenseDimension:
+            if isinstance(d, DenseDimension):
                 i += 1
-            else:
-                if d.id < d.other_id:
+            elif d.id < d.other_id:
                     i += 1
     return i
 
@@ -889,10 +914,9 @@ def _get_val_dim_when_swapped(st: SparseTensor, id: int) -> int:
     i = 0
     for d in dims[:id]:
         if d.val_dim is not None:
-            if type(d) is DenseDimension:
+            if isinstance(d, DenseDimension):
                 i += 1
-            else:
-                if d.id > d.other_id:
+            elif d.id > d.other_id:
                     i += 1
     return i
     
@@ -933,7 +957,7 @@ def _replicate_along_axis(st: SparseTensor, ids: Sequence[int]) -> SparseTensor:
     tiling = []              
     for d in dims:
         if d.val_dim is not None:
-            if type(d) is DenseDimension:
+            if isinstance(d, DenseDimension):
                 if st.val.shape[d.val_dim] != d.size:
                     tiling.append(d.size)
                 else:
@@ -950,7 +974,7 @@ def _replicate_along_axis(st: SparseTensor, ids: Sequence[int]) -> SparseTensor:
     return st
 
 
-def _get_contracting_axes(lhs: SparseTensor, rhs: SparseTensor) -> Tuple[Sequence[int], Sequence[int]]:
+def _get_contracting_axes(lhs: SparseTensor, rhs: SparseTensor) -> tuple[Sequence[int], Sequence[int]]:
     """
     Function that computes the axes along which the `val` properties of two
     `SparseTensor` objects will get contracted. This is necessary to enable
@@ -964,14 +988,14 @@ def _get_contracting_axes(lhs: SparseTensor, rhs: SparseTensor) -> Tuple[Sequenc
                             replicate along a given axis.
     
     Returns:
-        Tuple[Sequence[int], Sequence[int]]: Tuple of sequences of integers that
+        tuple[Sequence[int], Sequence[int]]: tuple of sequences of integers that
                                             tell us along which axes the `val`
                                             properties of `lhs` and `rhs` will
                                             get contracted.
     """
     lcontracting_axes, rcontracting_axes = [], []
     for (ld, rd) in zip(lhs.primal_dims, rhs.out_dims):
-        if type(ld) is DenseDimension and type(rd) is DenseDimension:
+        if isinstance(ld, DenseDimension) and isinstance(rd, DenseDimension):
             if ld.val_dim is not None and rd.val_dim is not None:
                 lcontracting_axes.append(ld.val_dim)
                 rcontracting_axes.append(rd.val_dim)
@@ -1071,7 +1095,7 @@ def _mixed_mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
     
     # We do contractions first    
     for (ld, rd) in zip(lhs.primal_dims, rhs.out_dims):
-        if type(ld) is DenseDimension and type(rd) is DenseDimension:
+        if isinstance(ld, DenseDimension) and isinstance(rd, DenseDimension):
             if ld.val_dim is None and rd.val_dim is None:
                 lreplication_ids.append(ld.id-l+len(lhs.out_dims))
                 rreplication_ids.append(rd.id)
@@ -1098,7 +1122,7 @@ def _mixed_mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
     # NOTE: SparseDimension and a DenseDimension with val_dim = None basically get rid
     # of a single jnp.diagonal call!
     for (ld, rd) in zip(lhs.primal_dims, rhs.out_dims):
-        if type(ld) is SparseDimension or type(rd) is SparseDimension:
+        if isinstance(ld, SparseDimension) or isinstance(rd, SparseDimension):
             # Here, we have a broadcasting over two tensors that are not just
             # Kronecker deltas
             if ld.val_dim is not None and rd.val_dim is not None and lhs.val.shape[ld.val_dim] == ld.size and rhs.val.shape[rd.val_dim] == rd.size:
@@ -1108,9 +1132,9 @@ def _mixed_mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
                 lbroadcasting_axes.append(ld.val_dim)
                 rbroadcasting_axes.append(rd.val_dim)
                 # The following cases cover ...
-                if type(rd) is DenseDimension:
+                if isinstance(rd, DenseDimension):
                     new_out_dims.insert(ld.other_id, DenseDimension(ld.other_id, ld.size, lval_dim))
-                elif type(ld) is DenseDimension:
+                elif isinstance(ld, DenseDimension):
                     new_primal_dims.insert(rd.other_id-r, DenseDimension(rd.other_id-r+l, ld.size, lval_dim))
                 else:
                     new_out_dims.insert(ld.other_id, SparseDimension(ld.other_id, ld.size, lval_dim, rd.other_id-r+l))
@@ -1123,7 +1147,7 @@ def _mixed_mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
                 # dimensions
                 # The following cases cover ...
                 # TODO simplify this piece of code.
-                if type(rd) is DenseDimension:
+                if isinstance(rd, DenseDimension):
                     # ld sparse
                     val_dim = None
                     if ld.val_dim is not None:
@@ -1134,7 +1158,7 @@ def _mixed_mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
                                 + lhs.val.ndim - sum([1 for lc in lcontracting_axes]) \
                                 - sum([1 for lb in lbroadcasting_axes])
                     new_out_dims.insert(ld.id, DenseDimension(ld.other_id, ld.size, val_dim))
-                elif type(ld) is DenseDimension:
+                elif isinstance(ld, DenseDimension):
                     # rd sparse
                     val_dim = None
                     if rd.val_dim is not None:
@@ -1172,22 +1196,22 @@ def _mixed_mul(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
     
     # Take care of the old dimensions
     for ld in lhs.out_dims:
-        if type(ld) is DenseDimension:
+        if isinstance(ld, DenseDimension):
             val_dim = None
             if ld.val_dim is not None:
                 val_dim = sum([1 for d in new_out_dims[:ld.id] if d.val_dim is not None])
             new_out_dims.insert(ld.id, DenseDimension(ld.id, ld.size, ld.val_dim))
     
     for rd in rhs.primal_dims:
-        if type(rd) is DenseDimension:
+        if isinstance(rd, DenseDimension):
             val_dim = None
             if rd.val_dim is not None:
                 # TODO add documentation here
                 num_old_lhs_out_dims = sum([1 for ld in lhs.out_dims 
-                                            if type(ld) is DenseDimension and ld.val_dim is not None])
+                                            if isinstance(ld, DenseDimension) and ld.val_dim is not None])
                 num_old_rhs_out_dims = sum([1 for rd in rhs.out_dims if rd.val_dim is not None])
                 num_sparse_dims = sum([1 for ld, rd in zip(lhs.primal_dims, rhs.out_dims) 
-                                       if (type(ld) is SparseDimension or type(rd) is SparseDimension) 
+                                       if (isinstance(ld, SparseDimension) or isinstance(rd, SparseDimension)) 
                                        and (ld.val_dim is not None or rd.val_dim is not None)])
                 val_dim = rd.val_dim + num_old_lhs_out_dims + num_sparse_dims - num_old_rhs_out_dims
             new_primal_dims.insert(rd.id-r, DenseDimension(rd.id-r+l, rd.size, val_dim))
@@ -1244,7 +1268,8 @@ def _sparse_add(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
         SparseTensor: SparseTensor object with `val` property resulting from
                         the sparse addition of `lhs.val` and `rhs.val`.
     """    
-    assert lhs.shape == rhs.shape, f"Incompatible shapes {lhs.shape} and {rhs.shape} for addition!"
+    assert lhs.shape == rhs.shape, \
+        f"Incompatible shapes {lhs.shape} and {rhs.shape} for addition!"
     ldims, rdims = [], []
     new_out_dims, new_primal_dims = [], []
     _lshape, _rshape = [], [] 
@@ -1269,19 +1294,19 @@ def _sparse_add(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
             dim = count
             count += 1
             
-        if type(ld) is SparseDimension and type(rd) is SparseDimension and ld.other_id == rd.other_id:
+        if isinstance(ld, SparseDimension) and isinstance(rd, SparseDimension) and ld.other_id == rd.other_id:
             new_out_dims.append(SparseDimension(ld.id, ld.size, dim, ld.other_id))
             _lshape.append(1)
             _rshape.append(1)
-        elif type(ld) is SparseDimension and type(rd) is SparseDimension and ld.other_id != rd.other_id:
+        elif isinstance(ld, SparseDimension) and isinstance(rd, SparseDimension) and ld.other_id != rd.other_id:
             new_out_dims.append(DenseDimension(ld.id, ld.size, dim))
             _lshape.append(ld.size)
             _rshape.append(ld.size)
         else:
-            if type(ld) is SparseDimension:
+            if isinstance(ld, SparseDimension):
                 _rshape.append(1)
                 _lshape.append(ld.size)
-            elif type(rd) is SparseDimension:
+            elif isinstance(rd, SparseDimension):
                 _rshape.append(rd.size)
                 _lshape.append(1)
             else:
@@ -1291,7 +1316,7 @@ def _sparse_add(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
             
     # Check the dimensionality of the 'primal_dims' of both tensors        
     for (ld, rd) in zip(lhs.primal_dims, rhs.primal_dims):                 
-        if type(ld) is SparseDimension and type(rd) is SparseDimension and ld.other_id == rd.other_id:
+        if isinstance(ld, SparseDimension) and isinstance(rd, SparseDimension) and ld.other_id == rd.other_id:
             dim = new_out_dims[ld.other_id].val_dim
             new_primal_dims.append(SparseDimension(ld.id, ld.size, dim, ld.other_id))
             # _lshape.append(1)
@@ -1316,15 +1341,15 @@ def _sparse_add(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
             
             # TODO something here is not right, there is an apparent asymetry
             # between the cases for ld and rd!
-            if type(ld) is SparseDimension and type(rd) is SparseDimension and ld.other_id != rd.other_id:
+            if isinstance(ld, SparseDimension) and isinstance(rd, SparseDimension) and ld.other_id != rd.other_id:
                 _lshape.append(ld.size)
                 _rshape.append(ld.size)
-            elif type(ld) is SparseDimension:
+            elif isinstance(ld, SparseDimension):
                 _lshape.append(ld.size)
                 if ld.val_dim is not None:
                     ldims.append(dim) # -1 # TODO fix this error!
                 _rshape.append(1)
-            elif type(rd) is SparseDimension:
+            elif isinstance(rd, SparseDimension):
                 _rshape.append(rd.size)
                 if rd.val_dim is not None:
                     rdims.append(dim) # -1 # TODO fix this error!
@@ -1344,10 +1369,10 @@ def _sparse_add(lhs: SparseTensor, rhs: SparseTensor) -> SparseTensor:
     _rdims = rhs.out_dims + rhs.primal_dims
     i = 0
     for (ld, rd) in zip(_ldims, _rdims):
-        if type(ld) is DenseDimension and ld.val_dim is None and rd.val_dim is not None:
+        if isinstance(ld, DenseDimension) and ld.val_dim is None and rd.val_dim is not None:
             ltiling[i] = ld.size
             i+= 1
-        elif type(rd) is DenseDimension and rd.val_dim is None and ld.val_dim is not None:
+        elif isinstance(rd, DenseDimension) and rd.val_dim is None and ld.val_dim is not None:
             rtiling[i] = ld.size
             i += 1
     
@@ -1373,21 +1398,21 @@ def get_num_muls(lhs: SparseTensor, rhs: SparseTensor) -> int:
     # of two SparseTensor objects  
     num_muls = 1
     for d in lhs.out_dims:
-        if type(d) is DenseDimension:
+        if isinstance(d, DenseDimension):
             if d.val_dim is not None:
                 num_muls *= d.size
             
     for ld, rd in zip(lhs.primal_dims, rhs.out_dims):
-        if type(ld) is DenseDimension and type(rd) is DenseDimension:
+        if isinstance(ld, DenseDimension) and isinstance(rd, DenseDimension):
             num_muls *= ld.size
             
-        elif type(ld) is DenseDimension and type(rd) is SparseDimension:
+        elif isinstance(ld, DenseDimension) and isinstance(rd, SparseDimension):
             num_muls *= ld.size
             
-        elif type(ld) is SparseDimension and type(rd) is DenseDimension:
+        elif isinstance(ld, SparseDimension) and isinstance(rd, DenseDimension):
             num_muls *= rd.size
             
-        elif type(ld) is SparseDimension and type(rd) is SparseDimension:
+        elif isinstance(ld, SparseDimension) and isinstance(rd, SparseDimension):
             if ld.val_dim is not None and rd.val_dim is not None:
                 m = max([lhs.val.shape[ld.val_dim], rhs.val.shape[rd.val_dim]])
                 num_muls *= m
@@ -1406,7 +1431,7 @@ def get_num_muls(lhs: SparseTensor, rhs: SparseTensor) -> int:
                         num_muls *= ld.size
 
     for d in rhs.primal_dims:
-        if type(d) is DenseDimension:
+        if isinstance(d, DenseDimension):
             if d.val_dim is not None:
                 num_muls *= d.size
                                 
@@ -1430,22 +1455,22 @@ def get_num_adds(lhs: SparseTensor, rhs: SparseTensor) -> int:
     num_adds = 1
     
     for ld, rd in zip(lhs.out_dims, rhs.out_dims):
-        if type(ld) is DenseDimension and type(rd) is DenseDimension:
+        if isinstance(ld, DenseDimension) and isinstance(rd, DenseDimension):
             num_adds *= ld.size
-        elif type(ld) is DenseDimension and type(rd) is SparseDimension:
+        elif isinstance(ld, DenseDimension) and isinstance(rd, SparseDimension):
             num_adds *= rd.size
-        elif type(ld) is SparseDimension and type(rd) is DenseDimension:
+        elif isinstance(ld, SparseDimension) and isinstance(rd, DenseDimension):
             num_adds *= ld.size
-        elif type(ld) is SparseDimension and type(rd) is SparseDimension:     
+        elif isinstance(ld, SparseDimension) and isinstance(rd, SparseDimension):     
             if ld.val_dim is not None and rd.val_dim is not None:    
                 num_adds *= ld.size
                 
     for ld, rd in zip(lhs.primal_dims, rhs.primal_dims):
-        if type(ld) is DenseDimension and type(rd) is DenseDimension:
+        if isinstance(ld, DenseDimension) and isinstance(rd, DenseDimension):
             num_adds *= ld.size
-        elif type(ld) is DenseDimension and type(rd) is SparseDimension:
+        elif isinstance(ld, DenseDimension) and isinstance(rd, SparseDimension):
             num_adds *= rd.size
-        elif type(ld) is SparseDimension and type(rd) is DenseDimension:
+        elif isinstance(ld, SparseDimension) and isinstance(rd, DenseDimension):
             num_adds *= ld.size
     return num_adds
     

--- a/tests/vmap_test.py
+++ b/tests/vmap_test.py
@@ -19,7 +19,9 @@ vmap_f = jax.vmap(f, in_axes=(0, 0))
 jacrev_f = jax.jit(jacve(vmap_f, order="rev", argnums=(0, 1), count_ops=True))
 jaxpr = jax.make_jaxpr(jacrev_f)(x, y)
 print(jaxpr)
-veres = jacrev_f(x, y)
+
+# results in a tuple with resulting jacobian and metrics dict (num_adds, num, mulls, and order_counts)
+veres, _ = jacrev_f(x, y)
 print(veres)
 
 jac_f = jax.jit(jax.jacrev(vmap_f, argnums=(0, 1)))


### PR DESCRIPTION
Imrpovements include:
- `xyz is type(abc)` to `isinstance(xyz, abc)`
- rename `_checkify_tensor` to `_assert_sparse_tensor_consistency` and move assertion inside the function
- use dataclasses for *Dimensions
- update types to match internal use (e.g. instead of general `Sequence` use `list` or `tuple`)
- use default binary operators within `_assert_sparse_tensor_consistency` instead of `int` operations
- better `__repr__`
- simplified typing (e.g. use `|` instead of Union, and `tuple[...]` instead of importing `Tuple` for the same purpose]
- combine logical statements (`if` and `assert`)
- improve text wrapping
- use generators within `all(...)`